### PR TITLE
Check for null return from malloc in C API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,6 @@ if(LIBXML2_FOUND)
   include_directories(${LIBXML2_INCLUDE_DIR})
 endif()
 
-CHECK_FUNCTION_EXISTS(strlcpy HAVE_STRLCPY)
-
 configure_file (
   "${AlpinoCorpus_SOURCE_DIR}/include/config.hh.in"
   "${AlpinoCorpus_BINARY_DIR}/include/config.hh"

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -95,13 +95,10 @@ char *alpinocorpus_iter_value(alpinocorpus_iter iter)
     }
     
     size_t len = entry.size() + 1;
-    char *cstr = reinterpret_cast<char *>(malloc(sizeof(char) * len));
-#ifdef HAVE_STRLCPY 
-    strlcpy(cstr, entry.c_str(), len);
-#else
-    strcpy(cstr, entry.c_str());
-#endif /* HAS_STRLCPY */
-    return cstr;    
+    char *cstr = std::malloc(len);
+    if (cstr != NULL)
+        std::memcpy(cstr, entry.c_str(), len);
+    return cstr;
 }
 
 char *alpinocorpus_read(alpinocorpus_reader reader, char const *entry)
@@ -114,12 +111,9 @@ char *alpinocorpus_read(alpinocorpus_reader reader, char const *entry)
     }
     
     size_t len = str.size() + 1;
-    char *cstr = reinterpret_cast<char *>(malloc(sizeof(char) * len));
-#ifdef HAVE_STRLCPY 
-    strlcpy(cstr, str.c_str(), len);
-#else
-    strcpy(cstr, str.c_str());
-#endif /* HAS_STRLCPY */
+    char *cstr = std::malloc(len);
+    if (cstr)
+        std::memcpy(cstr, str.c_cstr(), len);
     return cstr;
 }
 
@@ -146,12 +140,9 @@ char *alpinocorpus_read_mark_queries(alpinocorpus_reader reader,
     }
     
     size_t len = str.size() + 1;
-    char *cstr = reinterpret_cast<char *>(malloc(sizeof(char) * len));
-#ifdef HAVE_STRLCPY 
-    strlcpy(cstr, str.c_str(), len);
-#else
-    strcpy(cstr, str.c_str());
-#endif /* HAS_STRLCPY */
+    char *cstr = std::malloc(len);
+    if (cstr)
+        std::memcpy(cstr, str.c_str(), len);
     return cstr;
 }
 


### PR DESCRIPTION
I was bored and decided to do some C++ hacking. I caught you using `malloc` without testing its return value! :)

Also:
- no need for `strlcpy`, use `memcpy` instead
- don't cast the result from `malloc`, that [hides bugs](http://en.wikipedia.org/wiki/C_dynamic_memory_allocation#Disadvantages_to_casting)!
- `sizeof(char) == 1` per definition in the C++ standard
