### PR TITLE
Set up GitHub actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: "Test"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    strategy:
+      matrix:
+        channel:
+          - "https://nixos.org/channels/nixos-20.03"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v7
+    - run: nix-channel --add ${{ matrix.channel }} nixpkgs
+    - run: nix-channel --update
+    - run: nix-build

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,13 @@
-with import <nixpkgs> {};
-stdenv.mkDerivation rec {
-  name = "alpinocorpus-env";
-  env = buildEnv { name = name; paths = buildInputs; };
+{
+  pkgs ? import <nixpkgs> {}
+}:
+
+with pkgs;
+
+stdenv.mkDerivation {
+  name = "alpinocorpus";
+
+  src = nix-gitignore.gitignoreSource [ ".git/" ] ./.;
 
   nativeBuildInputs = [
     cmake
@@ -16,5 +22,20 @@ stdenv.mkDerivation rec {
     xercesc
     xqilla
     zlib
-  ];
+  ] ++ lib.optional stdenv.isDarwin libiconv;
+
+  doInstallCheck = true;
+
+  # Tests currently only work after installation, since the library
+  # paths are not set up correctly.
+  installCheckPhase = ''
+    make test
+  '';
+
+   meta = with stdenv.lib; {
+    description = "Library for Alpino treebanks";
+    homepage = "https://github.com/rug-compling/alpinocorpus";
+    license = licenses.lgpl21;
+    platforms = platforms.unix;
+  }; 
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+with import <nixpkgs> {};
+stdenv.mkDerivation rec {
+  name = "alpinocorpus-env";
+  env = buildEnv { name = name; paths = buildInputs; };
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+  ];
+
+  buildInputs = [
+    boost
+    dbxml
+    libxml2
+    libxslt
+    xercesc
+    xqilla
+    zlib
+  ];
+}


### PR DESCRIPTION
We use Nix to build alpinocorpus, since it makes it easy to pull in
all the right dependencies (e.g. DB XML).