### PR TITLE
Move from Boost regexes to standard library regexes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 
 include(GNUInstallDirs REQUIRED)
 
-find_package(Boost 1.50 COMPONENTS system filesystem regex REQUIRED)
+find_package(Boost 1.50 COMPONENTS system filesystem REQUIRED)
 
 if(Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})
@@ -135,6 +135,7 @@ set(HEADERS
   src/util/base64.hh
   src/util/bufutil.hh
   src/util/parseString.hh
+  src/util/split.hh
   src/util/textfile.hh
   src/util/url.hh
 )
@@ -163,6 +164,7 @@ set(SOURCES
   src/macros.cpp
   src/parseMacros.cpp
   src/util/NameCompare.cpp
+  src/util/split.cpp
   src/util/textfile.cpp
   src/util/url.cpp
 )

--- a/src/CorpusReader.cpp
+++ b/src/CorpusReader.cpp
@@ -3,13 +3,11 @@
 #include <cstring>
 #include <list>
 #include <memory>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include <boost/algorithm/string/regex.hpp>
-#include <boost/regex.hpp>
 
 #include <AlpinoCorpus/CorpusInfo.hh>
 #include <AlpinoCorpus/CorpusReader.hh>
@@ -35,6 +33,7 @@
 #include "FilterIter.hh"
 #include "StylesheetIter.hh"
 #include "util/parseString.hh"
+#include "util/split.hh"
 
 namespace xerces = XERCES_CPP_NAMESPACE;
 
@@ -241,8 +240,7 @@ namespace alpinocorpus {
         std::string const &defaultValue,
         CorpusInfo const &corpusInfo) const
     {
-        std::vector<std::string> queries;
-        boost::split_regex(queries, query, boost::regex("\\+\\|\\+"));
+        auto queries = split_string(query, std::regex("\\+\\|\\+"));
         assert(queries.size() > 0);
 
         // Discard pre-filters
@@ -307,8 +305,7 @@ namespace alpinocorpus {
     
     Either<std::string, Empty> CorpusReader::isValidQuery(QueryDialect d, bool variables, std::string const &q) const
     {
-        std::vector<std::string> queries;
-        boost::split_regex(queries, q, boost::regex("\\+\\|\\+"));
+        auto queries = split_string(q, std::regex("\\+\\|\\+"));
         assert(queries.size() > 0);
 
         for (std::vector<std::string>::const_iterator iter = queries.begin();
@@ -338,8 +335,7 @@ namespace alpinocorpus {
         for (std::list<MarkerQuery>::iterator iter = effectiveQueries.begin();
             iter != effectiveQueries.end(); ++iter)
         {
-            std::vector<std::string> queries;
-            boost::split_regex(queries, iter->query, boost::regex("\\+\\|\\+"));
+            auto queries = split_string(iter->query, std::regex("\\+\\|\\+"));
             assert(queries.size() > 0);
             iter->query = queries.back();
         }
@@ -545,8 +541,7 @@ namespace alpinocorpus {
     {
         if (d == XPATH)
         {
-            std::vector<std::string> queries;
-            boost::split_regex(queries, q, boost::regex("\\+\\|\\+"));
+            auto queries = split_string(q, std::regex("\\+\\|\\+"));
             assert(queries.size() > 0);
 
             EntryIterator qIter = runXPath(queries[0], sortOrder);

--- a/src/util/split.cpp
+++ b/src/util/split.cpp
@@ -1,0 +1,14 @@
+#include <algorithm>
+#include <regex>
+#include <string>
+#include <vector>
+
+std::vector<std::string> split_string(std::string const &s, std::regex const &re) {
+  std::vector<std::string> parts;
+
+  std::copy(std::sregex_token_iterator(s.begin(), s.end(), re, -1),
+	    std::sregex_token_iterator(),
+	    std::back_inserter(parts));
+
+  return parts;
+}

--- a/src/util/split.hh
+++ b/src/util/split.hh
@@ -1,0 +1,5 @@
+#include <regex>
+#include <string>
+#include <vector>
+
+std::vector<std::string> split_string(std::string const &s, std::regex const &re);


### PR DESCRIPTION
Regular expressions are currently only used for query
pipelines. Comments:

- The regular expression should be precompiled.
- We do not need regular expressions for this application.