### PR TITLE
Do not wrap lib{xml,xslt} includes in extern C

### DIFF
--- a/include/AlpinoCorpus/Stylesheet.hh
+++ b/include/AlpinoCorpus/Stylesheet.hh
@@ -5,9 +5,7 @@
 
 #include <memory>
 
-extern "C" {
 #include <libxslt/xsltInternals.h>
-}
 
 namespace alpinocorpus {
 

--- a/src/Stylesheet.cpp
+++ b/src/Stylesheet.cpp
@@ -2,14 +2,12 @@
 
 #include <memory>
 
-extern "C" {
 #include <libxml/globals.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <libxslt/xslt.h>
 #include <libxslt/transform.h>
 #include <libxslt/xsltutils.h>
-}
 
 #include <AlpinoCorpus/Error.hh>
 #include <AlpinoCorpus/Stylesheet.hh>

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -24,12 +24,12 @@ alpinocorpus::SortOrder to_sort_order(sort_order_t sort_order) {
     }
 }
 
-extern "C" {
-
 #include <libxslt/xslt.h>
 #include <libxml/parser.h>
 #include <libxml/xpath.h>
 #include <libexslt/exslt.h>
+
+extern "C" {
 
 void alpinocorpus_initialize()
 {

--- a/util/xslt/main.cpp
+++ b/util/xslt/main.cpp
@@ -4,12 +4,10 @@
 #include <string>
 #include <unordered_set>
 
-extern "C" {
 #include <libxslt/xslt.h>
 #include <libxml/parser.h>
 #include <libxml/xpath.h>
 #include <libexslt/exslt.h>
-}
 
 #include <AlpinoCorpus/CorpusReader.hh>
 #include <AlpinoCorpus/Entry.hh>


### PR DESCRIPTION
lib{xml,xslt} have header guards nowadays.

Fixes #60.